### PR TITLE
Additional adaptation for ubuntu

### DIFF
--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -221,7 +221,7 @@ if $isPrimary; then
 	echo
 	echo Here is a suggested password that is a random UUID, in case you like 
 	echo what you see:
-	nodejs -e "var uuid = require('node-uuid'); console.log(uuid.v4());"
+	node -e "var uuid = require('node-uuid'); console.log(uuid.v4());"
 	echo
 
 	read -s -p "Please enter a new password for the 'clusteradmin' MongoDB user: " primaryPasscode
@@ -339,10 +339,10 @@ if $isPrimary; then
 	echo Generating replica set security key...
 	openssl rand -base64 753 > $replicaSetKey
 	echo Securely storing replica set key in Azure storage...
-	nodejs updown.js mongodb up $replicaSetKey
+	node updown.js mongodb up $replicaSetKey
 else
 	echo Acquiring replica set security key from the cloud...
-	nodejs updown.js mongodb down $replicaSetKey
+	node updown.js mongodb down $replicaSetKey
 fi
 
 echo Installing replica set key on the machine...
@@ -410,7 +410,7 @@ EOF
 	echo http://docs.mongodb.org/manual/tutorial/add-user-to-database/
 	echo 
 	echo To connect to a Mongo instance:
-	echo   mongo MYDB -u Username -p
+	echo   mongo MYDB -u username -p password
 	echo
 
 	if ask "Would you like to connect to MongoDB Shell now as 'clusteradmin' to do this? "; then

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -80,7 +80,7 @@ sudo npm install -g npm@latest
 # ./nave.sh use 0.10.26
 
 nodeInstalled=$(node --version)
-if [ "$nodeInstalled" != "v0.10.36" ]; then
+if [ -z "$nodeInstalled" ]; then
         echo Node.js could not be installed.
         exit 1
 fi

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 
-# Copyright (c) Microsoft.  All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,12 +81,12 @@ sudo npm install -g npm@latest
 
 nodeInstalled=$(node --version)
 if [ -z "$nodeInstalled" ]; then
-        echo Node.js could not be installed.
-        exit 1
+	echo ----ERROR---- Node.js could not be installed.
+	exit 1
 fi
 
 echo Installing Azure Node.js module...
-npm install azure@0.8.1  > /tmp/nodeInstall.log 2>&1
+npm install azure@0.8.1 > /tmp/nodeInstall.log 2>&1
 
 echo Installing Azure storage utility...
 wget --no-check-certificate https://raw.github.com/jeffwilcox/waz-updown/master/updown.js > /tmp/updownInstall.log 2>&1
@@ -120,34 +120,33 @@ fi
 
 # Awesome ask function by @davejamesmiller https://gist.github.com/davejamesmiller/1965569
 function ask {
-    while true; do
- 
-        if [ "${2:-}" = "Y" ]; then
-            prompt="Y/n"
-            default=Y
-        elif [ "${2:-}" = "N" ]; then
-            prompt="y/N"
-            default=N
-        else
-            prompt="y/n"
-            default=
-        fi
- 
-        # Ask the question
-        read -p "$1 [$prompt] " REPLY
- 
-        # Default?
-        if [ -z "$REPLY" ]; then
-            REPLY=$default
-        fi
- 
-        # Check if the reply is valid
-        case "$REPLY" in
-            Y*|y*) return 0 ;;
-            N*|n*) return 1 ;;
-        esac
- 
-    done
+	while true; do
+
+		if [ "${2:-}" = "Y" ]; then
+			prompt="Y/n"
+			default=Y
+		elif [ "${2:-}" = "N" ]; then
+			prompt="y/N"
+			default=N
+		else
+			prompt="y/n"
+			default=
+		fi
+
+		# Ask the question
+		read -p "$1 [$prompt] " REPLY
+
+		# Default?
+		if [ -z "$REPLY" ]; then
+			REPLY=$default
+		fi
+
+		# Check if the reply is valid
+		case "$REPLY" in
+			Y*|y*) return 0 ;;
+			N*|n*) return 1 ;;
+		esac
+	done
 }
 
 
@@ -224,15 +223,19 @@ if $isPrimary; then
 	node -e "var uuid = require('node-uuid'); console.log(uuid.v4());"
 	echo
 
-	read -s -p "Please enter a new password for the 'clusteradmin' MongoDB user: " primaryPasscode
-	echo
-	read -s -p "Please confirm that awesome new password: " primaryPasscodeConfirmation
-	echo
+	primaryPasscode="wont"
+	primaryPasscodeConfirmation="match"
 
-	if [ "$primaryPasscode" != "$primaryPasscodeConfirmation" ]; then
-		echo The passwords did not match. Sorry. Goodbye.
-		exit 1
-	fi
+	while [ "$primaryPasscode" != "$primaryPasscodeConfirmation" ]
+	do
+		if [ "$primaryPasscode" != "wont" ]; then
+			echo The passwords did not match, please try again.
+		fi
+		read -s -p "Please enter a new password for the 'clusteradmin' MongoDB user: " primaryPasscode
+		echo
+		read -s -p "Please confirm that awesome new password: " primaryPasscodeConfirmation
+		echo
+	done
 
 fi
 
@@ -288,7 +291,7 @@ w
 ENDPARTITION
 
 	echo Formatting w/ext4...
-	sudo mkfs.ext4 /dev/sdc1  > /tmp/format.log 2>&1
+	sudo mkfs.ext4 /dev/sdc1 > /tmp/format.log 2>&1
 
 	echo Preparing permanent data disk mount point at /mnt/data...
 	sudo mkdir /mnt/data
@@ -314,25 +317,25 @@ sudo chown -R mongodb:mongodb /var/run/mongodb
 echo Configuring MongoDB 2.6...
 sudo tee /etc/mongod.conf > /dev/null <<EOF
 systemLog:
-    destination: file
-    path: "/var/log/mongodb/mongod.log"
-    quiet: true
-    logAppend: true
+		destination: file
+		path: "/var/log/mongodb/mongod.log"
+		quiet: true
+		logAppend: true
 processManagement:
-    fork: true
-    pidFilePath: "/var/run/mongodb/mongod.pid"
+		fork: true
+		pidFilePath: "/var/run/mongodb/mongod.pid"
 net:
-    port: $mongodPort
+		port: $mongodPort
 security:
-    keyFile: "/etc/$replicaSetKey"
-    authorization: "enabled"
+		keyFile: "/etc/$replicaSetKey"
+		authorization: "enabled"
 storage:
-    dbPath: "$mongoDataPath/db"
-    directoryPerDB: true
-    journal:
-        enabled: true
+		dbPath: "$mongoDataPath/db"
+		directoryPerDB: true
+		journal:
+				enabled: true
 replication:
-    replSetName: "$replicaSetName"
+		replSetName: "$replicaSetName"
 EOF
 
 if $isPrimary; then
@@ -375,19 +378,19 @@ EOF
 	/usr/bin/mongo /tmp/initializeReplicaSetPrimary.js > /tmp/creatingMongoCluster.log 2>&1
 
 	sleep 10
-	
+
 	echo Creating cluster administrator account...
 	cat <<EOF > /tmp/initializeAuthentication.js
 db = db.getSiblingDB('admin');
 db.createUser({
-  user: 'clusteradmin',
-  pwd: '$primaryPasscode',
-  roles: [
-    'userAdminAnyDatabase',
-    'clusterAdmin',
-    { db: 'config', role: 'readWrite' },
-    { db: 'local', role: 'read' }
-  ]
+	user: 'clusteradmin',
+	pwd: '$primaryPasscode',
+	roles: [
+		'userAdminAnyDatabase',
+		'clusterAdmin',
+		{ db: 'config', role: 'readWrite' },
+		{ db: 'local', role: 'read' }
+	]
 });
 EOF
 

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -166,7 +166,7 @@ primaryHostname=$(hostname)
 
 ### CONFIGURATION
 
-read -p "What is the name of the replica set? (Recommended: rs0) " replicaSetName
+read -p "What is the name of the replica set? (Default: rs0) " replicaSetName
 
 if [ -z "$replicaSetName" ]; then
 	replicaSetName=rs0
@@ -223,12 +223,12 @@ if $isPrimary; then
 	node -e "var uuid = require('node-uuid'); console.log(uuid.v4());"
 	echo
 
-	primaryPasscode="wont"
-	primaryPasscodeConfirmation="match"
+	primaryPasscodeConfirmation="$primaryPasscode somethingExtraSoItDoesntMatch"
+	tempPasscodeHolder="$primaryPasscode"
 
 	while [ "$primaryPasscode" != "$primaryPasscodeConfirmation" ]
 	do
-		if [ "$primaryPasscode" != "wont" ]; then
+		if [ "$primaryPasscode" != "$tempPasscodeHolder" ]; then
 			echo The passwords did not match, please try again.
 		fi
 		read -s -p "Please enter a new password for the 'clusteradmin' MongoDB user: " primaryPasscode
@@ -236,6 +236,8 @@ if $isPrimary; then
 		read -s -p "Please confirm that awesome new password: " primaryPasscodeConfirmation
 		echo
 	done
+
+	tempPasscodeHolder=
 
 fi
 

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -89,7 +89,7 @@ echo Installing Azure Node.js module...
 npm install azure@0.8.1 > /tmp/nodeInstall.log 2>&1
 
 echo Installing Azure storage utility...
-wget --no-check-certificate https://raw.github.com/jeffwilcox/waz-updown/master/updown.js > /tmp/updownInstall.log 2>&1
+wget --no-check-certificate https://raw.githubusercontent.com/jeffwilcox/waz-updown/master/updown.js > /tmp/updownInstall.log 2>&1
 
 
 

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -72,8 +72,8 @@ sudo npm install -g npm@latest
 # ./nave.sh install 0.10.26
 # ./nave.sh use 0.10.26
 
-nodeInstalled=$(nodejs -v)
-if [ "$nodeInstalled" != "v0.10.25" ]; then
+nodeInstalled=$(node --version)
+if [ "$nodeInstalled" != "v0.10.36" ]; then
         echo Node.js could not be installed.
         exit 1
 fi

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -63,8 +63,12 @@ pushd /tmp > /dev/null
 ### PREREQ SOFTWARE
 
 echo Installing Node.js...
+sudo apt-get update && apt-get install -y curl git
+sudo curl -sL https://deb.nodesource.com/setup | sudo bash -
 sudo apt-get install -y nodejs
-sudo apt-get install -y npm
+sudo npm install -g npm@latest
+# sudo apt-get install -y nodejs
+# sudo apt-get install -y npm
 # ./nave.sh install 0.10.26
 # ./nave.sh use 0.10.26
 

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -361,7 +361,7 @@ echo
 
 echo Starting MongoDB service...
 sudo service mongod start
-sudo chkconfig mongod on
+sudo update-rc.d mongod defaults
 
 if $isPrimary; then
 

--- a/setupMongoNode.sh
+++ b/setupMongoNode.sh
@@ -58,7 +58,14 @@ echo
 
 pushd /tmp > /dev/null
 
+### FORCE LOCALE SETTINGS
 
+echo Forcing locale settings to en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+locale-gen en_US.UTF-8
+sudo dpkg-reconfigure locales
 
 ### PREREQ SOFTWARE
 


### PR DESCRIPTION
I did manage to get the script working once, although the final line (attemptin run `mongo` from the script) fails. After that, I can acces the DB on the same node. Still, the whole replica set doen't seem to be working, from the outside.

The upgrades include:
- Node installation and usage upgraded for latest available version of node.js
- Fix for missing locale settings that would cause `mongo` not to work
- Misstyping the `clusteradmin` passcode no longer kills the script (asks again)
- Changed `chkconfig` for ubuntu's `update-rc.d` (needs further testing maybe)
